### PR TITLE
VFS issue fix for building armv7/pandaboardES

### DIFF
--- a/usr/examples/xmpl-crystal-readwrite/Hakefile
+++ b/usr/examples/xmpl-crystal-readwrite/Hakefile
@@ -14,8 +14,15 @@
 --		or addLibraries = libDeps ["vfs_noblockdev"]
 --------------------------------------------------------------------------
 
-[ build application { target = "examples/xmpl-crystal-readwrite",
+[
+  build application { target = "examples/xmpl-crystal-readwrite",
                       addLibraries = libDeps ["vfs"],
-                      cFiles = [ "readwrite.c" ]
+                      cFiles = [ "readwrite.c" ],
+                      architectures = [ "x86_64", "x86_32", "k1om" ]
+                    },
+  build application { target = "examples/xmpl-crystal-readwrite",
+                      addLibraries = libDeps ["vfs_noblockdev"],
+                      cFiles = [ "readwrite.c" ],
+                      architectures = [ "armv7", "armv8" ]
                     }
 ]


### PR DESCRIPTION
The example's Hakefile now uses appropriate VFS version depending on arch.

It builds through to image generation.