### PR TITLE
Dockerfile add hake -armv7 and make PandaboardES,PandboardES_Min

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,6 @@ COPY . ${BF_HOME}
 WORKDIR ${BF_HOME}
 RUN mkdir -pv results
 RUN mkdir -pv build && cd build && ../hake/hake.sh -s .. -a x86_64
+#RUN cd build && make -j5 PandaboardES
+#RUN cd build && make -j5 PandaboardES_Min
 CMD ./tools/harness/runtests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,7 @@ RUN pip install --upgrade pip && pip install gitpython pexpect
 COPY . ${BF_HOME}
 WORKDIR ${BF_HOME}
 RUN mkdir -pv results
-RUN mkdir -pv build && cd build && ../hake/hake.sh -s .. -a x86_64
+RUN mkdir -pv build && cd build && ../hake/hake.sh -s .. -a x86_64 -a armv7
+RUN cd build && make -j5 PandaboardES
+RUN cd build && make -j5 PandaboardES_Min
 CMD ./tools/harness/runtests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,4 @@ COPY . ${BF_HOME}
 WORKDIR ${BF_HOME}
 RUN mkdir -pv results
 RUN mkdir -pv build && cd build && ../hake/hake.sh -s .. -a x86_64
-#RUN cd build && make -j5 PandaboardES
-#RUN cd build && make -j5 PandaboardES_Min
 CMD ./tools/harness/runtests.py


### PR DESCRIPTION
This PR passes circle CI (dockerfile_hake_make_arm #36)

Although the continuous integration doesn't actually run the arm builds, this pull request adds instructions to the Dockerfile to make PandaboardES and PandaboardES_Min anyway. This will at least catch things we are committing that don't build.