### PR TITLE
Remove x86 min and fix x86 boot problems

### DIFF
--- a/hake/menu.lst.x86_64
+++ b/hake/menu.lst.x86_64
@@ -24,20 +24,20 @@ module	/x86_64/sbin/monitor
 # Special boot time domains spawned by monitor
 module  /x86_64/sbin/ramfsd boot
 module  /x86_64/sbin/skb boot
-#modulenounzip /eclipseclp_ramfs.cpio.gz nospawn
-#modulenounzip /skb_ramfs.cpio.gz nospawn
-#module  /x86_64/sbin/kaluga boot
-#module  /x86_64/sbin/acpi boot
-#module  /x86_64/sbin/spawnd boot
-#bootapic-x86_64=1-15
-#module  /x86_64/sbin/startd boot
-#module /x86_64/sbin/routing_setup boot
+modulenounzip /eclipseclp_ramfs.cpio.gz nospawn
+modulenounzip /skb_ramfs.cpio.gz nospawn
+module  /x86_64/sbin/kaluga boot
+module  /x86_64/sbin/acpi boot
+module  /x86_64/sbin/spawnd boot
+bootapic-x86_64=1-15
+module  /x86_64/sbin/startd boot
+module /x86_64/sbin/routing_setup boot
 
 # Drivers
-#module /x86_64/sbin/pci auto
-#module /x86_64/sbin/corectrl auto
-#module /x86_64/sbin/ahcid auto
-#module	/x86_64/sbin/serial_pc16550d auto
+module /x86_64/sbin/pci auto
+module /x86_64/sbin/corectrl auto
+module /x86_64/sbin/ahcid auto
+module	/x86_64/sbin/serial_pc16550d auto
 
 ## For networking
 #module /x86_64/sbin/rtl8029 auto
@@ -48,8 +48,8 @@ module  /x86_64/sbin/skb boot
 #module /x86_64/sbin/netd auto
 
 # General user domains
-#module  /x86_64/sbin/fish nospawn
-#module	/x86_64/sbin/angler serial0.terminal xterm
+module  /x86_64/sbin/fish nospawn
+module	/x86_64/sbin/angler serial0.terminal xterm
 
 #examples
 module  /x86_64/sbin/examples/xmpl-hello

--- a/platforms/Hakefile
+++ b/platforms/Hakefile
@@ -194,18 +194,6 @@ let bin_rcce_lu = [ "/sbin/" ++ f | f <- [
 
 
 
-    -- modules x86_64 min
-    modules_x86_64_Min = [ "/sbin/" ++ f | f <- [
-                           "elver",
-                           "cpu",
-                           "init",
-                           "skb",
-                           "spawnd",
-                           "startd",
-                           "mem_serv",
-                           "monitor",
-                           "ramfsd" ]]
-
 
     -- x86_64-specific modules to build by default
     -- this should shrink as targets are ported and move into the generic list above
@@ -451,12 +439,6 @@ let bin_rcce_lu = [ "/sbin/" ++ f | f <- [
        ++
        [ ("",       f) | f <- modules_generic])
       "64-bit x86 PC build with benchmarks and test suites",
-
-    platform "X86_64_Min" ["x86_64"]
-      ([ ("x86_64", f) | f <- modules_x86_64_Min ]
-       ++
-       [ ("",       f) | f <- modules_generic])
-      "x86_64 min description goes here",
 
 
     platform "K1OM_Basic" [ "k1om" ]


### PR DESCRIPTION
This pull request passes Circle CI: Harvard-PRINCESS / Guppy / remove_x86_MIN #46

- gets rid of unused x86_64_Min target that wasn't fully created
- uncomments a few modules in hake/menu.lst.x86_64, allowing x86_Basic and x86_Full to boot properly. This problem was not caught in the Circle CI tests because Harness creates a separate menu.lst for every test separately.
- we should potentially find a way to test our builds using the menu.lst's that we actually use locally.