### PR TITLE
Configure docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,4 @@ COPY . ${BF_HOME}
 WORKDIR ${BF_HOME}
 RUN mkdir -pv results
 RUN mkdir -pv build && cd build && ../hake/hake.sh -s .. -a x86_64 -a armv7
-RUN cd build && make -j5 PandaboardES
-RUN cd build && make -j5 PandaboardES_Min
-CMD ./tools/harness/runtests.py
+RUN cd build && make -j5 X86_64_Basic && make -j5 PandaboardES

--- a/circle.yml
+++ b/circle.yml
@@ -2,15 +2,10 @@ machine:
   services:
     - docker
 
-test:                                
-  override:
-    - docker run bf/qemu_x86_64
-
 dependencies:
-  cache_directories:
-    - "~/docker"
+  pre:
+    - sudo pip install docker-compose
 
-  override:
-    - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
-    - docker build --rm=false -t bf/qemu_x86_64 .
-    - mkdir -p ~/docker; docker save bf/qemu_x86_64 > ~/docker/image.tar
+test:
+  post:
+    - docker-compose up

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,11 @@
 machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
+    - pip install --upgrade pip
+    - pip install docker-compose
+
   services:
     - docker
-
-dependencies:
-  pre:
-    - sudo pip install docker-compose
 
 test:
   post:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '2'
+services:
+    qemu_x86_64: 
+        build: .
+        command: ./tools/harness/runtests.py

--- a/tools/harness/README
+++ b/tools/harness/README
@@ -100,17 +100,18 @@ Docker
 In the root of this repository there is a Dockerfile that builds and executes
 `runtest.py` against Barrelfish x86_64 on QEMU on an Ubuntu 16.04 image.
 
-To install Docker: [MacOS](https://docs.docker.com/docker-for-mac/install/),
+Installation:
+
+* Install Docker: [MacOS](https://docs.docker.com/docker-for-mac/install/),
 [Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntu/).
+* Install docker-compose (comes with Docker for Mac/Docker for Windows/Docker
+Toolk, and manual installation instructions for Ubuntu are
+[here](https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-16-04).
 
 Then, in your repository root, run:
 ```
-docker build . -t bf_qemu_x86
-docker run bf_qemu_x86
+docker-compose up
 ```
-
-The first time you build the image it has to install all the `apt`
-dependencies, but Docker caches builds and so it will be fast thereafter.
 
 INVOCATION EXAMPLES
 


### PR DESCRIPTION
[docker-compose](https://docs.docker.com/compose/overview/) is a tool for having multi-container Docker configurations in a project.

Currently, we just have a single Dockerfile that results in one image that will build for all the platforms we have (PandaboardES etc.) and then just run x86_64.

With docker-compose, we can have a different configuration each platform (each of which inherits our base Ubuntu image), and then when you run `docker-compose up` it will run every supported platform in a different Docker container in parallel.

docker-compose comes with Mac/Windows Docker distributions and Docker Toolbox, but I've also added a link to how to manually install on Ubuntu if that doesn't work (presumably, `pip` should just work but I guess it may be more involved than that).