### PR TITLE
move pinned_state def to generic core_state.h

### DIFF
--- a/include/arch/aarch64/barrelfish/core_state_arch.h
+++ b/include/arch/aarch64/barrelfish/core_state_arch.h
@@ -22,15 +22,6 @@ struct vspace_state {
     struct pmap_aarch64 pmap;
 };
 
-struct pinned_state {
-    struct thread_mutex mutex;
-    struct memobj_pinned memobj;
-    struct vregion vregion;
-    lvaddr_t offset;
-    struct slab_allocator vregion_list_slab;
-    struct slab_allocator frame_list_slab;
-};
-
 struct core_state_arch {
     struct core_state_generic c;
     struct vspace_state vspace_state;

--- a/include/arch/arm/barrelfish/core_state_arch.h
+++ b/include/arch/arm/barrelfish/core_state_arch.h
@@ -22,15 +22,6 @@ struct vspace_state {
     struct pmap_arm pmap;
 };
 
-struct pinned_state {
-    struct thread_mutex mutex;
-    struct memobj_pinned memobj;
-    struct vregion vregion;
-    lvaddr_t offset;
-    struct slab_allocator vregion_list_slab;
-    struct slab_allocator frame_list_slab;
-};
-
 struct core_state_arch {
     struct core_state_generic c;
     struct vspace_state vspace_state;

--- a/include/arch/x86/barrelfish/core_state_arch.h
+++ b/include/arch/x86/barrelfish/core_state_arch.h
@@ -22,15 +22,6 @@ struct vspace_state {
     struct pmap_x86 pmap;
 };
 
-struct pinned_state {
-    struct thread_mutex mutex;
-    struct memobj_pinned memobj;
-    struct vregion vregion;
-    lvaddr_t offset;
-    struct slab_allocator vregion_list_slab;
-    struct slab_allocator frame_list_slab;
-};
-
 struct core_state_arch {
     struct core_state_generic c;
     struct vspace_state vspace_state;

--- a/include/barrelfish/core_state.h
+++ b/include/barrelfish/core_state.h
@@ -100,4 +100,13 @@ struct core_state_generic {
     struct skb_state skb_state;
 };
 
+struct pinned_state {
+    struct thread_mutex mutex;
+    struct memobj_pinned memobj;
+    struct vregion vregion;
+    lvaddr_t offset;
+    struct slab_allocator vregion_list_slab;
+    struct slab_allocator frame_list_slab;
+};
+
 #endif


### PR DESCRIPTION
There's a structure in the architecture-dependent core_state_arch.h that could be in the generic core_state.h, so I moved it. Boots on qemu and ARMv7 gem5/Pandaboard both.