### PR TITLE
a few hake fixes that should make it upstream

### DIFF
--- a/hake/hake.sh
+++ b/hake/hake.sh
@@ -49,7 +49,7 @@ usage() {
     echo "  argument specifying the top of the source tree."
     echo ""
     echo "  Known architectures may include: "
-    echo "     x86_64 x86_32 armv7 armv8 k10m"
+    echo "     x86_64 x86_32 armv7 armv8 k1om"
     exit 1;
 }
 

--- a/lib/compiler-rt/builtins/Hakefile
+++ b/lib/compiler-rt/builtins/Hakefile
@@ -271,6 +271,7 @@ let
                                   "x86_32"  -> [ ]
                                   "armv7"   -> [ "-D__ARM_EABI__" ]
                                   "armv8"   -> [ ]
+                                  x -> error ("Unknown architecture for compiler-rt: " ++ x)
 
 in [
     build library {

--- a/lib/compiler-rt/test/Hakefile
+++ b/lib/compiler-rt/test/Hakefile
@@ -191,6 +191,7 @@ let
                                   "x86_32"  -> [ ]
                                   "armv7"   -> [ "-D__ARM_EABI__" ]
                                   "armv8"   -> [ ]
+                                  x -> error ("Unknown architecture for compiler-rt: " ++ x)
 
   builtins_unittest_dir = "test/builtins/Unit/"
 


### PR DESCRIPTION
1. hake.sh advises you on the wrong known architectures; it lists k10m (with a zero) instead of k1om (with a lowercase letter 'o')
2. a case match in compiler-rt will cause interpretation of the concatenated Hakefile pile to throw an incomplete case error (on some anonymous segment of the dynamically created string, which cannot be inspected) when an unrecognized architecture is put in, instead of generating any kind of comprehensible message---so I put in the relevant error cases